### PR TITLE
Container should not be passed as an argument

### DIFF
--- a/DependencyInjection/DeveloidTranslatorExtension.php
+++ b/DependencyInjection/DeveloidTranslatorExtension.php
@@ -5,6 +5,7 @@ namespace Develoid\TranslatorBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
@@ -25,8 +26,6 @@ class DeveloidTranslatorExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
-
-        $container->setParameter('develoid_translator.default', $config['default']);
 
         if (isset($config['yandex'])) {
             $this->createDefinition(
@@ -58,6 +57,11 @@ class DeveloidTranslatorExtension extends Extension
                 ])
             ;
         }
+
+        $container->getDefinition('develoid_translator.default_translator')->replaceArgument(
+            0,
+            new Reference(sprintf('develoid_translator.%s_translator', $config['default']))
+        );
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,4 +6,4 @@ parameters:
 services:
     develoid_translator.default_translator:
         class: Develoid\TranslatorBundle\Translator
-        arguments: [ @service_container, %develoid_translator.default% ]
+        arguments: [ "" ]

--- a/Translator.php
+++ b/Translator.php
@@ -3,7 +3,6 @@
 namespace Develoid\TranslatorBundle;
 
 use Develoid\TranslatorBundle\Model\TranslatorInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Translator implements TranslatorInterface
 {
@@ -13,12 +12,11 @@ class Translator implements TranslatorInterface
     private $translator;
 
     /**
-     * @param ContainerInterface $container
-     * @param string $default
+     * @param TranslatorInterface $translator
      */
-    public function __construct(ContainerInterface $container, $default)
+    public function __construct(TranslatorInterface $translator)
     {
-        $this->translator = $container->get(sprintf('develoid_translator.%s_translator', $default));
+        $this->translator = $translator;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

The Symfony Dependency Injection Container should not be passed as an argument.

BC breaks: The ``develoid_translator.default`` parameter is removed.