### PR TITLE
Remove token generation in Microsoft translator constructor

### DIFF
--- a/Microsoft/Translator.php
+++ b/Microsoft/Translator.php
@@ -63,7 +63,7 @@ class Translator implements TranslatorInterface
         $this->client = new Client();
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
-        $this->accessToken  = $this->getToken();
+        $this->accessToken  = null;
     }
 
     /**
@@ -128,7 +128,7 @@ class Translator implements TranslatorInterface
         try {
             $response = $this->client->get($url, [
                 'headers' => [
-                    'Authorization' => 'Bearer ' . $this->accessToken,
+                    'Authorization' => 'Bearer ' . $this->getToken(),
                     'Content-Type' => 'text/xml'
                 ]
             ]);
@@ -152,6 +152,10 @@ class Translator implements TranslatorInterface
      */
     private function getToken()
     {
+        if (null !== $this->accessToken) {
+            return $this->accessToken;
+        }
+
         try {
             $config = [
                 'grant_type' => $this->grantType,
@@ -166,7 +170,9 @@ class Translator implements TranslatorInterface
             $body = (string) $response->getBody();
             $body = json_decode($body, true);
 
-            return $body['access_token'];
+            $this->accessToken = $body['access_token'];
+
+            return $this->accessToken;
         } catch (ClientException $e) {
             $body = (string) $e->getResponse()->getBody();
             $error = json_decode($body, true);


### PR DESCRIPTION
When a service `my_service` has `develoid_translator.microsoft_translator`dependency, the Translator constructor is called when `my_service` is called even if the translator is not called.

But the Translator constructor generates Microsoft token (and generates a HTTP request)